### PR TITLE
Override declared adapter at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bananarama</groupId>
     <artifactId>bananarama</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.9.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>BananaRama</name>
     <description>A simple cross-persistence access library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bananarama</groupId>
     <artifactId>bananarama</artifactId>
-    <version>0.9.10-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>BananaRama</name>
     <description>A simple cross-persistence access library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bananarama</groupId>
     <artifactId>bananarama</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>BananaRama</name>
     <description>A simple cross-persistence access library</description>

--- a/src/main/java/org/bananarama/BananaRama.java
+++ b/src/main/java/org/bananarama/BananaRama.java
@@ -76,13 +76,9 @@ public class BananaRama implements Adapter<Object>{
             return getAdapter(customAdapters.get(clazz));
         }
         
-        if(!clazz.isAnnotationPresent(Banana.class))    {
-            if(clazz.getName().equals("com.google.cloud.datastore.Entity")) {
-                System.out.println("ASDASDSADSADA");
-            }
+        if(!clazz.isAnnotationPresent(Banana.class)) {
             throw new IllegalArgumentException(clazz.getName() + " is not annotated with " + Banana.class.getName());
-        }
-            
+        }           
         
         // If type was annotated for buffering, we retrieve the IndexedCollectionAdapter
         if(clazz.isAnnotationPresent(BufferedOnIndexedCollection.class))

--- a/src/main/java/org/bananarama/BananaRama.java
+++ b/src/main/java/org/bananarama/BananaRama.java
@@ -42,10 +42,18 @@ public class BananaRama implements Adapter<Object>{
     
     private final StripedLock slock;
     private final Map<Class<?>, Adapter<?>> adapters;
-    private static final Map<Class<?>, Class<? extends Adapter>> customAdapters = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Class<? extends Adapter>> customAdapters = new ConcurrentHashMap<>();
     
-    public static void registerAdapter(Class<? extends Adapter> adapter, Class forEntiy) {
+    /**
+     * Map the specified {@link Adapter} for a given entity. 
+     * This method is usefull to allow final class from external libraries to be managed by BananaRama
+     * @param adapter
+     * @param forEntiy 
+     * @return this instance
+     */
+    public BananaRama registerAdapter(Class<? extends Adapter> adapter, Class forEntiy) {
         customAdapters.put(forEntiy, adapter);
+        return this;
     }
     
     public BananaRama(){

--- a/src/test/java/basic/ListAdapter.java
+++ b/src/test/java/basic/ListAdapter.java
@@ -35,12 +35,6 @@ public class ListAdapter implements Adapter<Object>{
 
     private final List<Object> backend = new ArrayList<>();
 
-    public ListAdapter() {
-        System.out.println("uallaualla");
-    }
-    
-    
-    
     @Override
     public <T> CreateOperation<T> create(Class<T> clazz) {
        return new CreateOperation<T>() {

--- a/src/test/java/basic/ListAdapter.java
+++ b/src/test/java/basic/ListAdapter.java
@@ -35,11 +35,17 @@ public class ListAdapter implements Adapter<Object>{
 
     private final List<Object> backend = new ArrayList<>();
 
+    public ListAdapter() {
+        System.out.println("uallaualla");
+    }
+    
+    
+    
     @Override
     public <T> CreateOperation<T> create(Class<T> clazz) {
        return new CreateOperation<T>() {
            @Override
-           public CreateOperation<T> from(Stream<T> data) {
+           public CreateOperation<T> from(Stream<T> data) {               
                data.forEach(backend::add);
                return this;
            }

--- a/src/test/java/magic/cascade/ForceCustomAdaptersTest.java
+++ b/src/test/java/magic/cascade/ForceCustomAdaptersTest.java
@@ -1,0 +1,81 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package magic.cascade;
+
+import basic.ListAdapter;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+import magic.SimpleDto;
+import magic.SimpleMapper;
+import magic.SimpleObj;
+import org.bananarama.BananaRama;
+import org.bananarama.annotation.Banana;
+import org.bananarama.annotation.MapWith;
+import org.bananarama.crud.magic.MagicAdapter;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Tommaso Doninelli <tommaso.doninelli@gmail.com>
+ */
+public class ForceCustomAdaptersTest {
+    
+    @Test
+    public void useAnotherAdapter() throws NoSuchMethodException {
+     
+        Random rnd = new Random();
+        
+        /*
+            SimpleObj has a MagicAdapter, that convert to SimpleDto;
+            SimpleDto has a ListAdapter. 
+            SimpleDto is representing a class declared final that comes from a third-party library,
+            a class for which is not possible to declare the adapter at compile time.        
+        */
+        
+        // Verify all the assumptions
+        
+        // SimpleObj is babanaed with a MAgicAdapter that map using SimpleMapper
+        Assert.assertEquals(
+               SimpleMapper.class, 
+               Optional.ofNullable(SimpleObj.class.getDeclaredAnnotation(MapWith.class))
+                    .map(MapWith::value)
+                    .get());
+
+        // SimpleMapper map to SimpleDto
+        Assert.assertNotNull(SimpleMapper.class.getDeclaredMethod("toObj", SimpleDto.class));
+       
+        // SimpleDto is bananaed using a ListAdapter
+        Assert.assertEquals(
+               ListAdapter.class, 
+               Optional.ofNullable(SimpleDto.class.getDeclaredAnnotation(Banana.class))
+                    .map(Banana::adapter)
+                    .get());
+       
+        Assert.assertEquals(0, MemoryAdapter.datastore.size());
+     
+        // Override the declared adapter (only for this run)        
+        new BananaRama()
+                .registerAdapter(MemoryAdapter.class, SimpleObj.class)
+                .create(SimpleObj.class)
+                .from(Stream.of(new SimpleObj(rnd.nextInt()), new SimpleObj(rnd.nextInt())));
+                
+        Assert.assertEquals(2, MemoryAdapter.datastore.size());
+        Assert.assertEquals(0, new BananaRama().read(SimpleObj.class).all().count());
+        
+        MemoryAdapter.datastore.clear();
+        BananaRama banana = new BananaRama();
+        
+        banana
+                .create(SimpleObj.class)
+                .from(Stream.of(new SimpleObj(rnd.nextInt()), new SimpleObj(rnd.nextInt())));
+        
+        Assert.assertEquals(0, MemoryAdapter.datastore.size()); 
+        Assert.assertEquals(2, banana.read(SimpleObj.class).all().count());
+    }
+    
+}

--- a/src/test/java/magic/cascade/ForceCustomAdaptersTest.java
+++ b/src/test/java/magic/cascade/ForceCustomAdaptersTest.java
@@ -39,22 +39,20 @@ public class ForceCustomAdaptersTest {
         
         // Verify all the assumptions
         
-        // SimpleObj is babanaed with a MAgicAdapter that map using SimpleMapper
-        Assert.assertEquals(
-               SimpleMapper.class, 
-               Optional.ofNullable(SimpleObj.class.getDeclaredAnnotation(MapWith.class))
+        // SimpleObj is babanaed with a MagicAdapter that map using SimpleMapper
+        Class declaredMapWith = Optional.ofNullable(SimpleObj.class.getDeclaredAnnotation(MapWith.class))
                     .map(MapWith::value)
-                    .get());
+                    .get();
+        Assert.assertEquals(SimpleMapper.class, declaredMapWith);
 
         // SimpleMapper map to SimpleDto
         Assert.assertNotNull(SimpleMapper.class.getDeclaredMethod("toObj", SimpleDto.class));
        
         // SimpleDto is bananaed using a ListAdapter
-        Assert.assertEquals(
-               ListAdapter.class, 
-               Optional.ofNullable(SimpleDto.class.getDeclaredAnnotation(Banana.class))
+        Class declaredAdapter = Optional.ofNullable(SimpleDto.class.getDeclaredAnnotation(Banana.class))
                     .map(Banana::adapter)
-                    .get());
+                    .get();
+        Assert.assertEquals(ListAdapter.class, declaredAdapter);
        
         Assert.assertEquals(0, MemoryAdapter.datastore.size());
      

--- a/src/test/java/magic/cascade/MemoryAdapter.java
+++ b/src/test/java/magic/cascade/MemoryAdapter.java
@@ -31,7 +31,7 @@ public class MemoryAdapter implements Adapter<Object>{
 
             @Override
             public CreateOperation<T> from(Stream<T> data, QueryOptions options) {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
@@ -49,27 +49,27 @@ public class MemoryAdapter implements Adapter<Object>{
 
             @Override
             public Stream<T> all(QueryOptions options) {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
             public <Q> Stream<T> where(Q whereClause) {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
             public <Q> Stream<T> where(Q whereClause, QueryOptions options) {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
             public Stream<T> fromKeys(List<?> keys) {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
             public Stream<T> fromKeys(List<?> keys, QueryOptions options) {
-                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
@@ -79,14 +79,11 @@ public class MemoryAdapter implements Adapter<Object>{
 
     @Override
     public <T> UpdateOperation<T> update(Class<T> clazz) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public <T> DeleteOperation<T> delete(Class<T> clazz) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-    
-    
-    
+        throw new UnsupportedOperationException("Not supported yet.");
+    }    
 }

--- a/src/test/java/magic/cascade/MemoryAdapter.java
+++ b/src/test/java/magic/cascade/MemoryAdapter.java
@@ -1,0 +1,92 @@
+package magic.cascade;
+
+import com.googlecode.cqengine.query.option.QueryOptions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.bananarama.crud.Adapter;
+import org.bananarama.crud.CreateOperation;
+import org.bananarama.crud.DeleteOperation;
+import org.bananarama.crud.ReadOperation;
+import org.bananarama.crud.UpdateOperation;
+
+/**
+ * Simple adapter that store data in a public static map
+ * @author Tommaso Doninelli <tommaso.doninelli@gmail.com>
+ */
+public class MemoryAdapter implements Adapter<Object>{
+    
+    protected static final List<Object> datastore = Collections.synchronizedList(new ArrayList<>());
+    
+    @Override
+    public <T> CreateOperation<T> create(Class<T> clazz) {
+        return new CreateOperation<T>() {
+            @Override
+            public CreateOperation<T> from(Stream<T> data) {
+                data.forEach(datastore::add);
+                return this;
+            }
+
+            @Override
+            public CreateOperation<T> from(Stream<T> data, QueryOptions options) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void close() throws IOException {}
+        };
+    }
+
+    @Override
+    public <T> ReadOperation<T> read(Class<T> clazz) {
+        return new ReadOperation<T>() {
+            @Override
+            public Stream<T> all() {
+                return (Stream<T>) datastore.stream();
+            }
+
+            @Override
+            public Stream<T> all(QueryOptions options) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <Q> Stream<T> where(Q whereClause) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <Q> Stream<T> where(Q whereClause, QueryOptions options) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Stream<T> fromKeys(List<?> keys) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Stream<T> fromKeys(List<?> keys, QueryOptions options) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void close() throws IOException {}
+        };
+    }
+
+    @Override
+    public <T> UpdateOperation<T> update(Class<T> clazz) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public <T> DeleteOperation<T> delete(Class<T> clazz) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+    
+    
+}


### PR DESCRIPTION
With this change it is possible to
- override, at runtime, the declared adapter for a class.
- register an adapter for a final class that declared in a library, for which is impossible to add an annotation at compile time.

The usecase is the same defined in the test: a class (`SimpleObj`) that is persisted using a dto (`SimpleDto`); so `SimpleObj` is annotated with `@Banana(adapter = MagicAdapter.class)`. 
We can consider `SimpleDto` as a class declared in an external library

In this case, `BananaRama.using()` overrides only the first adapter, so it is not a working alternative
