### PR TITLE
Added all method to delete adapters

### DIFF
--- a/src/main/java/org/bananarama/cache/CacheDeleteOperation.java
+++ b/src/main/java/org/bananarama/cache/CacheDeleteOperation.java
@@ -109,4 +109,15 @@ public class CacheDeleteOperation<T> extends AbstractCacheOperation<T> implement
     public void close() throws IOException {
         
     }
+    
+    /**
+    * {@inheritDoc}
+    */
+    @Override
+    public DeleteOperation<T> all() {
+
+        getBackingAdapter(clazz).delete(clazz).all();
+        coll.clear();
+        return this;
+    }
 }

--- a/src/main/java/org/bananarama/crud/DeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/DeleteOperation.java
@@ -53,4 +53,11 @@ public interface DeleteOperation <T> extends BasicOperation{
      * @return
      */
     public DeleteOperation<T> from(Stream<T> data,QueryOptions options);
+    
+    /**
+     * Delete all records from the persisted layer.
+     * @param data The collection of objects to be removed
+     * @return
+     */
+    public DeleteOperation<T> all();
 }

--- a/src/main/java/org/bananarama/crud/jpa/JpaDeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/jpa/JpaDeleteOperation.java
@@ -80,4 +80,20 @@ public class JpaDeleteOperation<T> extends AbstractJpaOperation<T> implements De
         return from(data);
     }
     
+    /**
+    * {@inheritDoc}
+    */
+    @Override
+    public DeleteOperation<T> all() {
+
+        final EntityManager em = factory.createEntityManager();
+        em.getTransaction().begin();
+        em.createQuery(DELETE).executeUpdate();
+        em.getTransaction().commit();
+        
+        close(em);
+        
+        return this;
+    }
+    
 }

--- a/src/main/java/org/bananarama/crud/magic/MagicDeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/magic/MagicDeleteOperation.java
@@ -65,5 +65,15 @@ public class MagicDeleteOperation<O,D,M extends ObjToDto<O,D>> implements Delete
     public void close() throws IOException {
         deleteDto.close();
     }
+    /**
+    * {@inheritDoc}
+    */
+    @Override
+    public DeleteOperation<O> all() {
+
+        deleteDto.all();
+        return this;
+        
+    }
     
 }

--- a/src/main/java/org/bananarama/crud/noop/NoOpDeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/noop/NoOpDeleteOperation.java
@@ -53,4 +53,14 @@ public class NoOpDeleteOperation<T> implements DeleteOperation<T>{
         */
     }
     
+    /**
+    * {@inheritDoc}
+    */
+    @Override
+    public DeleteOperation<T> all() {
+
+        return this;
+        
+    }
+    
 }

--- a/src/main/java/org/bananarama/crud/sql/SqlDeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/sql/SqlDeleteOperation.java
@@ -69,14 +69,13 @@ public class SqlDeleteOperation<T> extends AbstractSqlOperation<T> implements De
     public <Q> SqlDeleteOperation<T> where(Q whereClause, QueryOptions options) {
         String currentTableName = getTableNameForCurrentSession(options);
         
-        String whereClauseString = null;
+        String whereClauseString = "";
         if (whereClause != null) {
             if(whereClause instanceof String)
                 whereClauseString = (String) whereClause;
             else if(whereClause instanceof com.googlecode.cqengine.query.Query)
                 whereClauseString = CQE2SQL.convertCqQuery((com.googlecode.cqengine.query.Query<?>) whereClause);            
-        }else
-            whereClauseString = "";
+        }
         
         String sql = "DELETE from " + currentTableName + whereClauseString;
         

--- a/src/main/java/org/bananarama/crud/sql/SqlDeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/sql/SqlDeleteOperation.java
@@ -70,10 +70,13 @@ public class SqlDeleteOperation<T> extends AbstractSqlOperation<T> implements De
         String currentTableName = getTableNameForCurrentSession(options);
         
         String whereClauseString = null;
-        if(whereClause instanceof String)
-            whereClauseString = (String) whereClause;
-        else if(whereClause instanceof com.googlecode.cqengine.query.Query)
-            whereClauseString = CQE2SQL.convertCqQuery((com.googlecode.cqengine.query.Query<?>) whereClause);
+        if (whereClause != null) {
+            if(whereClause instanceof String)
+                whereClauseString = (String) whereClause;
+            else if(whereClause instanceof com.googlecode.cqengine.query.Query)
+                whereClauseString = CQE2SQL.convertCqQuery((com.googlecode.cqengine.query.Query<?>) whereClause);            
+        }else
+            whereClauseString = "";
         
         String sql = "DELETE from " + currentTableName + whereClauseString;
         
@@ -125,6 +128,17 @@ public class SqlDeleteOperation<T> extends AbstractSqlOperation<T> implements De
                         .filter(FieldAccessor::isKey)
                         .map(FieldAccessor::getName),""," = ? AND "," = ?")
         );
+    }
+
+    
+    /**
+    * {@inheritDoc}
+    */
+    @Override
+    public DeleteOperation<T> all() {
+
+        return where(null);
+        
     }
 
 }

--- a/src/main/java/org/bananarama/crud/util/WeldingAdapter.java
+++ b/src/main/java/org/bananarama/crud/util/WeldingAdapter.java
@@ -190,6 +190,15 @@ public abstract class WeldingAdapter<S> implements Adapter<S>{
             public void close() throws IOException {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
+            @Override
+            public DeleteOperation<T> all() {
+
+                adapters.parallelStream()
+                .forEach(adapter -> adapter.delete(clazz).all());
+                
+                return this;
+                
+            }
         };
     }
     

--- a/src/main/java/org/bananarama/crud/util/WeldingAdapter.java
+++ b/src/main/java/org/bananarama/crud/util/WeldingAdapter.java
@@ -190,6 +190,7 @@ public abstract class WeldingAdapter<S> implements Adapter<S>{
             public void close() throws IOException {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
+			
             @Override
             public DeleteOperation<T> all() {
 
@@ -197,7 +198,6 @@ public abstract class WeldingAdapter<S> implements Adapter<S>{
                 .forEach(adapter -> adapter.delete(clazz).all());
                 
                 return this;
-                
             }
         };
     }

--- a/src/test/java/basic/ListAdapter.java
+++ b/src/test/java/basic/ListAdapter.java
@@ -153,6 +153,15 @@ public class ListAdapter implements Adapter<Object>{
            public void close() throws IOException {
                
            }
+           
+
+            @Override
+            public DeleteOperation<T> all() {
+    
+                backend.clear();
+                return this;
+                
+            }
        };
     }
     

--- a/src/test/java/basic/SimpleCrudTest.java
+++ b/src/test/java/basic/SimpleCrudTest.java
@@ -69,6 +69,14 @@ public class SimpleCrudTest {
         delete.from(Stream.of(entryUpdated));
         assertEquals(0, read.all().count());
         
+     
+        
+        create.from(Stream.of(entry));
+        
+        assertEquals(1, read.all().count());
+
+        delete.all();
+        assertEquals(0, read.all().count());
     }
     
     @Test

--- a/src/test/java/cache/cqengine/CacheTest.java
+++ b/src/test/java/cache/cqengine/CacheTest.java
@@ -105,6 +105,15 @@ public class CacheTest {
         bananarama.delete(CacheEntry.class).where(equal(CacheEntry.KEY,entryUpdated.getKey()));
         checkCount(0, read);
         
+        create.from(Stream.of(entry));
+        
+        checkCount(1, read);
+
+        bananarama.delete(CacheEntry.class).all();
+        checkCount(0, read);
+
+        
+        
         //Check indexes creation
         try{
             IndexedCollectionAdapter adap = bananarama.using(IndexedCollectionAdapter.class);

--- a/src/test/java/magic/TestMagic.java
+++ b/src/test/java/magic/TestMagic.java
@@ -106,5 +106,14 @@ public class TestMagic {
         magic.delete(SimpleObj.class).from(objs.stream());
         
         assertEquals("Magic Delete did now work",0,listAd.read(SimpleObj.class).all().count());
+        
+        
+        magic.create(SimpleObj.class).from(objs.stream()).andReturn();
+
+        magic.delete(SimpleObj.class).all();
+        
+        assertEquals("Magic Delete did now work",0,listAd.read(SimpleObj.class).all().count());
+
+        
     }
 }

--- a/src/test/java/sql/basic/SqlTest.java
+++ b/src/test/java/sql/basic/SqlTest.java
@@ -143,15 +143,17 @@ public class SqlTest {
         //Check that records were deleted
         Assert.assertEquals(0,reader.all().count());
         
+		// Now check the delete all functionality
         creator.from(created.stream());
-        
+        Assert.assertTrue(reader.all().count() > 0);
+		
         deleter.all();      
         
         //Check that records were deleted
         Assert.assertEquals(0,reader.all().count());
         
     }
-    
+	
     private void testBatchMultiId(int n){
         List<MultipleIdColPojo> created = IntStream.range(0,n)
                 .mapToObj(MultipleIdColPojo::newInstance)

--- a/src/test/java/sql/basic/SqlTest.java
+++ b/src/test/java/sql/basic/SqlTest.java
@@ -143,6 +143,13 @@ public class SqlTest {
         //Check that records were deleted
         Assert.assertEquals(0,reader.all().count());
         
+        creator.from(created.stream());
+        
+        deleter.all();      
+        
+        //Check that records were deleted
+        Assert.assertEquals(0,reader.all().count());
+        
     }
     
     private void testBatchMultiId(int n){

--- a/src/test/java/sql/jpa/JpaTest.java
+++ b/src/test/java/sql/jpa/JpaTest.java
@@ -86,6 +86,14 @@ public class JpaTest {
         delete.from(Stream.of(updated));
         
         checkCount(0, read);
+        
+        
+        create.from(Stream.of(simp));
+        checkCount(1, read);
+        delete.all();
+        checkCount(0, read);
+        
+        
     }
     
     @Test 


### PR DESCRIPTION
I added the method **all** to class **DeleteOperation** in order to remove instantaneously all the elements of a given Adapter.

Tests have been also modified to check this new feature.
