### PR TITLE
Corrected bug to get the real entity name to use in JPA delete operation

### DIFF
--- a/src/main/java/org/bananarama/crud/jpa/JpaDeleteOperation.java
+++ b/src/main/java/org/bananarama/crud/jpa/JpaDeleteOperation.java
@@ -33,7 +33,7 @@ public class JpaDeleteOperation<T> extends AbstractJpaOperation<T> implements De
     
     public JpaDeleteOperation(EntityManagerFactory factory,Class<T> clazz){
         super(factory,clazz);
-        DELETE = "DELETE from " + clazz.getSimpleName();
+        DELETE = "DELETE from " + getEntityName(clazz);
     }
     
     @Override

--- a/src/test/java/sql/jpa/Simpleton.java
+++ b/src/test/java/sql/jpa/Simpleton.java
@@ -35,7 +35,7 @@ import javax.persistence.ManyToMany;
  * 
  * @author Guglielmo De Concini
  */
-@Entity
+@Entity(name = "simple")
 @Banana(adapter = H2Adapter.class)
 public class Simpleton {
     private String description;


### PR DESCRIPTION
In JpaDeleteOperation is defined the constant DELETE that has to be used in the methods **where(Q obj, QueryOptions options)** and **all()**. The name of the target entity is taken using the simple java class name, but this not work if the class has the attribute **name** of the annotation **Entity** specified (and different from the class name). To get the correct name to consider, use the method getEntityName to init DELETE constant.
See the procedure use in the JpaReadOperation.
